### PR TITLE
fix(build): remove stale GitVersion.MsBuild reference

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <GlobalPackageReference Include="CSharpier.MSBuild" Version="1.2.6" />
-    <GlobalPackageReference Include="GitVersion.MsBuild" Version="6.7.0" />
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" />
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.300" />
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />


### PR DESCRIPTION
## Summary
Removes the \`GitVersion.MsBuild\` \`GlobalPackageReference\` from \`Directory.Packages.props\`.

## Why
This package forces GitVersion to run as an MSBuild target on every build, which requires full git history. The shared CI pipeline's test job checks out with \`fetch-depth: 1\`, so every build/test run in this repo currently fails with:

\`\`\`
Repository is a shallow clone. Git repositories must contain the full history.
\`\`\`

This blocks every currently open Renovate PR. The version is already computed externally and passed in via \`/p:Version\` by the pipeline's version-detection step — this is how every other repo in the org does it; none of them reference \`GitVersion.MsBuild\` at all. This repo is the only outlier still carrying the package, likely a leftover from before that centralized version step existed.

## Test plan
- [x] \`dotnet build\` succeeds locally
- [x] No other project file references \`GitVersion.MsBuild\` or reads its output