### PR TITLE
refactor(tests): replace NSubstitute with TUnit.Mocks

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.0.6" />
     <PackageVersion Include="NetEvolve.Arguments" Version="3.4.0" />
     <PackageVersion Include="NetEvolve.Logging.Abstractions" Version="2.0.303" />
-    <PackageVersion Include="NSubstitute" Version="6.0.0" />
+    <PackageVersion Include="TUnit.Mocks" Version="1.63.0" />
     <PackageVersion Include="Verify.ParametersHashing" Version="1.0.0" />
     <PackageVersion Include="Verify.XunitV3" Version="31.28.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/tests/NetEvolve.Logging.XUnit.Tests.Unit/NetEvolve.Logging.XUnit.Tests.Unit.csproj
+++ b/tests/NetEvolve.Logging.XUnit.Tests.Unit/NetEvolve.Logging.XUnit.Tests.Unit.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
-    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="TUnit.Mocks" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/NetEvolve.Logging.XUnit.Tests.Unit/XUnitLoggerTests.cs
+++ b/tests/NetEvolve.Logging.XUnit.Tests.Unit/XUnitLoggerTests.cs
@@ -2,7 +2,7 @@
 
 using System;
 using Microsoft.Extensions.Logging;
-using NSubstitute;
+using TUnit.Mocks;
 using Xunit;
 using Xunit.Sdk;
 
@@ -55,7 +55,7 @@ public partial class XUnitLoggerTests
     [Fact]
     public void CreateLogger_WithMessageSinkSubstituteAndTimeProviderNull_ThrowsArgumentNullException()
     {
-        var messageSink = Substitute.For<IMessageSink>();
+        var messageSink = Mock.Of<IMessageSink>().Object;
         TimeProvider timeProvider = null!;
 
         _ = Assert.Throws<ArgumentNullException>(
@@ -90,7 +90,7 @@ public partial class XUnitLoggerTests
     [Fact]
     public void CreateLoggerGeneric_WithMessageSinkSubstituteAndTimeProviderNull_ThrowsArgumentNullException()
     {
-        var messageSink = Substitute.For<IMessageSink>();
+        var messageSink = Mock.Of<IMessageSink>().Object;
         TimeProvider timeProvider = null!;
 
         _ = Assert.Throws<ArgumentNullException>(
@@ -122,7 +122,7 @@ public partial class XUnitLoggerTests
     [Fact]
     public void CreateLogger_WithTestOutputHelperSubstituteAndTimeProviderNull_ThrowsArgumentNullException()
     {
-        var testOutputHelper = Substitute.For<ITestOutputHelper>();
+        var testOutputHelper = Mock.Of<ITestOutputHelper>().Object;
         TimeProvider timeProvider = null!;
 
         _ = Assert.Throws<ArgumentNullException>(
@@ -157,7 +157,7 @@ public partial class XUnitLoggerTests
     [Fact]
     public void CreateLoggerGeneric_WithTestOutputHelperSubstituteAndTimeProviderNull_ThrowsArgumentNullException()
     {
-        var testOutputHelper = Substitute.For<ITestOutputHelper>();
+        var testOutputHelper = Mock.Of<ITestOutputHelper>().Object;
         TimeProvider timeProvider = null!;
 
         _ = Assert.Throws<ArgumentNullException>(


### PR DESCRIPTION
## Summary
- Replaces NSubstitute with TUnit.Mocks for the sole mocking use case in `XUnitLoggerTests.cs`
- Adopts `TUnit.Mocks` only (not the full TUnit test framework), since it works standalone with any test runner and this repo's only NSubstitute usage is 4 calls to `Substitute.For<T>()` with no behavior setup or call verification
- Removes the `NSubstitute` package reference

Closes #504

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors (all 3 target frameworks)
- [x] `dotnet build -p:CSharpier_Check=true` — formatting passes
- [x] `dotnet test` — 270/270 tests pass